### PR TITLE
DEVOPS-001: Remove data volume mount from vecpipe to enforce service boundaries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,6 @@ services:
     volumes:
       # Mount data directories
       # Note: Ensure host directories have appropriate permissions (uid 1000)
-      - ./data:/app/data
       - ./logs:/app/logs
       # Mount HuggingFace cache for persistent model storage
       - ${HF_CACHE_DIR:-./models}:/app/.cache/huggingface


### PR DESCRIPTION
## Summary
- Removed `./data` volume mount from vecpipe service in docker-compose.yml
- This enforces the architectural boundary between services, ensuring vecpipe cannot directly access the SQLite database
- Part of the three-tier architecture refactoring initiative

## Changes
- **docker-compose.yml**: Removed line 71 (`- ./data:/app/data`) from vecpipe service volumes

## Context
This change is part of ticket DEVOPS-001 to finalize and validate the Docker multi-service configuration after refactoring the codebase into three distinct packages (shared, vecpipe, webui).

The removal of the data volume mount from vecpipe ensures:
1. Only webui has direct access to the SQLite database
2. vecpipe must interact with webui through API endpoints
3. Clear service boundaries are maintained
4. The architecture follows proper dependency direction

## Test plan
- [x] Clean Docker build completed successfully (`docker compose build --no-cache`)
- [x] All services start without errors (`docker compose up -d`)
- [x] No ImportError exceptions in logs
- [x] Health checks pass for both webui and vecpipe services
- [x] Verified vecpipe container has no access to ./data directory

## Related
- Depends on: CORE-004 (Refactor vecpipe Maintenance Service)
- Blocks: TEST-004 (Execute E2E Test Suite)
- Part of: Three-tier architecture refactoring (REFACTORING_PLAN.md)