### PR TITLE
Implement production-ready JWT secret key handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # Production Configuration Example
 # Copy this file to /etc/semantik/config.env and update with your values
 
+# -- Environment Configuration --
+# Set to "production" for production deployments
+# In production, JWT_SECRET_KEY must be explicitly set
+ENVIRONMENT=production
+
 # -- Qdrant Configuration --
 QDRANT_HOST=your-qdrant-host
 QDRANT_PORT=6333

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ celerybeat.pid
 .env
 .env.backup
 .semantik-config.json
+.jwt_secret
 .venv
 env/
 venv/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,6 +40,8 @@ services:
         max-size: "100m"
         max-file: "5"
     environment:
+      # Production environment
+      - ENVIRONMENT=production
       # Production optimizations
       - PYTHONOPTIMIZE=2  # Remove docstrings and enable optimizations
       - MODEL_UNLOAD_AFTER_SECONDS=600  # Keep models loaded longer in production
@@ -62,6 +64,8 @@ services:
         max-size: "100m"
         max-file: "5"
     environment:
+      # Production environment
+      - ENVIRONMENT=production
       # Production settings
       - PYTHONOPTIMIZE=2
       - LOG_LEVEL=WARNING

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
     ports:
       - "8000:8000"
     environment:
+      # General configuration
+      - ENVIRONMENT=${ENVIRONMENT:-development}
       # Qdrant configuration
       - QDRANT_HOST=qdrant
       - QDRANT_PORT=6333
@@ -109,6 +111,8 @@ services:
     ports:
       - "8080:8080"
     environment:
+      # General configuration
+      - ENVIRONMENT=${ENVIRONMENT:-development}
       # Service URLs for inter-container communication
       - SEARCH_API_URL=http://vecpipe:8000
       - SEARCH_API_HOST=vecpipe

--- a/packages/shared/config/base.py
+++ b/packages/shared/config/base.py
@@ -15,6 +15,9 @@ class BaseConfig(BaseSettings):
     # Project root directory, calculated automatically
     PROJECT_ROOT: Path = Path(__file__).parent.parent.parent.parent.resolve()
 
+    # Environment Configuration
+    ENVIRONMENT: str = "development"  # Options: development, production
+
     # Qdrant Configuration
     QDRANT_HOST: str = "localhost"
     QDRANT_PORT: int = 6333

--- a/packages/shared/config/webui.py
+++ b/packages/shared/config/webui.py
@@ -1,8 +1,6 @@
 # shared/config/webui.py
 
-import os
 import secrets
-from pathlib import Path
 from typing import Any
 
 from .base import BaseConfig
@@ -32,10 +30,10 @@ class WebuiConfig(BaseConfig):
     def __init__(self, **kwargs: Any) -> None:
         """Initialize configuration with JWT secret key validation."""
         super().__init__(**kwargs)
-        
+
         # JWT Secret Key file path (in the data directory)
         jwt_secret_file = self.data_dir / ".jwt_secret"
-        
+
         # Handle JWT secret key based on environment
         if self.ENVIRONMENT == "production":
             # In production, JWT_SECRET_KEY must be explicitly set via environment variable
@@ -55,18 +53,19 @@ class WebuiConfig(BaseConfig):
                         if not self.JWT_SECRET_KEY:
                             raise ValueError("JWT secret file is empty")
                     except Exception as e:
-                        raise ValueError(f"Failed to read JWT secret from {jwt_secret_file}: {e}")
+                        raise ValueError(f"Failed to read JWT secret from {jwt_secret_file}: {e}") from e
                 else:
                     # Generate a new secret and save it to file
                     self.JWT_SECRET_KEY = secrets.token_hex(32)
                     try:
                         jwt_secret_file.write_text(self.JWT_SECRET_KEY)
                         # Set secure permissions (readable only by owner)
-                        os.chmod(jwt_secret_file, 0o600)
+                        jwt_secret_file.chmod(0o600)
                     except Exception as e:
                         # If we can't write the file, continue with the generated secret
                         # but warn the user
                         import logging
+
                         logging.warning(
                             f"Generated JWT secret key but failed to save to {jwt_secret_file}: {e}. "
                             "The key will be regenerated on next startup unless JWT_SECRET_KEY is set."

--- a/packages/shared/config/webui.py
+++ b/packages/shared/config/webui.py
@@ -1,5 +1,10 @@
 # shared/config/webui.py
 
+import os
+import secrets
+from pathlib import Path
+from typing import Any
+
 from .base import BaseConfig
 
 
@@ -23,3 +28,46 @@ class WebuiConfig(BaseConfig):
 
     # External service URLs
     SEARCH_API_URL: str = "http://localhost:8000"
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize configuration with JWT secret key validation."""
+        super().__init__(**kwargs)
+        
+        # JWT Secret Key file path (in the data directory)
+        jwt_secret_file = self.data_dir / ".jwt_secret"
+        
+        # Handle JWT secret key based on environment
+        if self.ENVIRONMENT == "production":
+            # In production, JWT_SECRET_KEY must be explicitly set via environment variable
+            if self.JWT_SECRET_KEY == "default-secret-key" or not self.JWT_SECRET_KEY:
+                raise ValueError(
+                    "JWT_SECRET_KEY must be explicitly set via environment variable in production. "
+                    "Generate a secure key using: openssl rand -hex 32"
+                )
+        else:
+            # In development, allow auto-generation or reading from file
+            if self.JWT_SECRET_KEY == "default-secret-key":
+                # Check if .jwt_secret file exists
+                if jwt_secret_file.exists():
+                    # Read the secret from file
+                    try:
+                        self.JWT_SECRET_KEY = jwt_secret_file.read_text().strip()
+                        if not self.JWT_SECRET_KEY:
+                            raise ValueError("JWT secret file is empty")
+                    except Exception as e:
+                        raise ValueError(f"Failed to read JWT secret from {jwt_secret_file}: {e}")
+                else:
+                    # Generate a new secret and save it to file
+                    self.JWT_SECRET_KEY = secrets.token_hex(32)
+                    try:
+                        jwt_secret_file.write_text(self.JWT_SECRET_KEY)
+                        # Set secure permissions (readable only by owner)
+                        os.chmod(jwt_secret_file, 0o600)
+                    except Exception as e:
+                        # If we can't write the file, continue with the generated secret
+                        # but warn the user
+                        import logging
+                        logging.warning(
+                            f"Generated JWT secret key but failed to save to {jwt_secret_file}: {e}. "
+                            "The key will be regenerated on next startup unless JWT_SECRET_KEY is set."
+                        )


### PR DESCRIPTION
## Summary
- Implement environment-based JWT secret validation to prevent insecure deployments
- Add automatic JWT secret generation for development environments
- Enforce explicit JWT_SECRET_KEY requirement for production environments

## Changes
- Added `ENVIRONMENT` configuration variable to distinguish between development and production
- Modified `WebuiConfig` to validate JWT secret based on environment:
  - **Production**: Fails on startup if JWT_SECRET_KEY is not explicitly set
  - **Development**: Auto-generates secure key and saves to `.jwt_secret` file
- Updated Docker configurations to include ENVIRONMENT variable
- Added `.jwt_secret` to `.gitignore` for security
- Updated `.env.example` with production configuration guidance

## Test Plan
- [ ] Verify development mode auto-generates JWT secret
- [ ] Verify production mode fails without JWT_SECRET_KEY
- [ ] Verify production mode succeeds with JWT_SECRET_KEY set
- [ ] Verify `.jwt_secret` file has secure permissions (0o600)
- [ ] Verify Docker containers start correctly with proper environment settings