### PR TITLE
TASK-3C: Deprecate job-centric API endpoints

### DIFF
--- a/DEPRECATED_ENDPOINTS_REMOVAL_TICKETS.md
+++ b/DEPRECATED_ENDPOINTS_REMOVAL_TICKETS.md
@@ -1,0 +1,52 @@
+# Deprecated Job-Centric Endpoints Removal Tickets
+
+These tickets track the complete removal of deprecated job-centric API endpoints after the v2.0 release.
+
+## TICKET-001: Remove Deprecated Job CRUD Endpoints
+**Priority**: Medium
+**Target Release**: Post v2.0
+**Dependencies**: None
+
+### Description
+Remove the following deprecated endpoints from `/packages/webui/api/jobs.py`:
+- `POST /api/jobs` - Create job endpoint
+- `GET /api/jobs` - List jobs endpoint
+- `GET /api/jobs/{job_id}` - Get job details endpoint
+- `DELETE /api/jobs/{job_id}` - Delete job endpoint
+
+### Acceptance Criteria
+- [ ] Remove endpoint implementations
+- [ ] Remove associated request/response models if no longer used
+- [ ] Update tests to remove deprecated endpoint coverage
+- [ ] Ensure no internal code references these endpoints
+
+## TICKET-002: Remove Job-Centric WebSocket Handler
+**Priority**: Low
+**Target Release**: Post v2.0
+**Dependencies**: TICKET-001
+
+### Description
+Remove the legacy job-based WebSocket handler at `/ws/{job_id}` in favor of the operation-based handler.
+
+### Acceptance Criteria
+- [ ] Remove `websocket_endpoint` function from jobs.py
+- [ ] Update main.py to remove the WebSocket route mounting
+- [ ] Update frontend to exclusively use operation-based WebSocket
+
+## TICKET-003: Clean Up Job-Centric Utility Functions
+**Priority**: Low
+**Target Release**: Post v2.0
+**Dependencies**: TICKET-001, TICKET-002
+
+### Description
+Remove any remaining job-centric utility functions and helpers that are no longer needed after the API removal.
+
+### Acceptance Criteria
+- [ ] Audit codebase for unused job-specific utilities
+- [ ] Remove deprecated functions
+- [ ] Update any remaining references to use collection-based alternatives
+
+## Notes
+- Since Semantik is pre-release, we have flexibility on timing
+- Monitor usage of deprecated endpoints before removal
+- Ensure all functionality is available through collection-based endpoints before removal

--- a/PHASE_3_DEV_LOG.md
+++ b/PHASE_3_DEV_LOG.md
@@ -624,3 +624,70 @@ The implementation follows the execution plan closely while maintaining backward
   - Real-time operation progress for all collection operations
   - Maintains backward compatibility during transition period
   - Clean separation of concerns between legacy and new systems
+
+---
+
+## TASK-3C: Deprecate & Phase Out Job-Centric API Endpoints
+
+### 2025-07-17 - Started TASK-3C Implementation
+- **Context**: Phase 3 review identified that old job-centric API endpoints still exist and need formal deprecation
+- **Goal**: Mark superseded endpoints as deprecated and prepare for eventual removal
+
+### 2025-07-17 - Completed Endpoint Analysis
+- **Job Endpoints Found**:
+  1. Main CRUD operations at `/api/jobs`:
+     - `POST /api/jobs` - Create new embedding job
+     - `GET /api/jobs` - List all jobs for user
+     - `GET /api/jobs/{job_id}` - Get specific job details
+     - `DELETE /api/jobs/{job_id}` - Delete job and collection
+  2. Collection-aware job endpoints (not deprecated):
+     - `POST /api/jobs/add-to-collection` - Add to existing collection
+     - `GET /api/jobs/collection-metadata/{name}` - Get collection metadata
+     - `POST /api/jobs/check-duplicates` - Check duplicate files
+     - `GET /api/jobs/collections-status` - Check Qdrant collections
+     - `GET /api/jobs/{job_id}/collection-exists` - Check if collection exists
+  3. Other endpoints (not deprecated):
+     - `GET /api/jobs/new-id` - Generate job ID for WebSocket
+     - `POST /api/jobs/{job_id}/cancel` - Cancel running job
+- **Collection Endpoints (replacements)**:
+  - `GET /api/collections` - List all collections with stats
+  - `GET /api/collections/{name}` - Get collection details
+  - `PUT /api/collections/{name}` - Rename collection
+  - `DELETE /api/collections/{name}` - Delete entire collection
+  - `GET /api/collections/{name}/files` - List files in collection
+
+### 2025-07-17 - Implemented Deprecation Markers
+- **Changes Made** (packages/webui/api/jobs.py):
+  1. Added `deprecated=True` to FastAPI router decorators for:
+     - `POST /api/jobs`
+     - `GET /api/jobs`
+     - `GET /api/jobs/{job_id}`
+     - `DELETE /api/jobs/{job_id}`
+  2. Added `logger.warning()` calls to deprecated endpoints:
+     - Each warning specifies which endpoint is deprecated
+     - Points to the collection-based replacement
+     - States removal timeline (v2.0)
+  3. Enhanced docstrings with deprecation notices:
+     - Added **DEPRECATED** section to each affected endpoint
+     - Provided migration guide for each endpoint
+     - Explained collection-centric alternatives
+- **Endpoints NOT Deprecated**:
+  - Collection-aware operations (add-to-collection, metadata, etc.)
+  - Utility endpoints (new-id, cancel)
+  - Internal API endpoints
+  - WebSocket handlers (handled separately)
+- **Documentation Updates**:
+  - Clear migration paths in docstrings
+  - Explains collection-centric model benefits
+  - Shows equivalent functionality in new endpoints
+
+### 2025-07-17 - Created Follow-up Removal Tickets
+- **Created** DEPRECATED_ENDPOINTS_REMOVAL_TICKETS.md:
+  - TICKET-001: Remove deprecated job CRUD endpoints
+  - TICKET-002: Remove job-centric WebSocket handler
+  - TICKET-003: Clean up job-centric utility functions
+  - Notes about pre-release flexibility
+- **Removal Strategy**:
+  - Monitor deprecated endpoint usage via logs
+  - Ensure feature parity before removal
+  - Clean removal post-v2.0 release

--- a/packages/webui/api/jobs.py
+++ b/packages/webui/api/jobs.py
@@ -80,7 +80,7 @@ async def get_new_job_id(current_user: dict[str, Any] = Depends(get_current_user
     return {"job_id": str(uuid.uuid4())}
 
 
-@router.post("", response_model=JobStatus)
+@router.post("", response_model=JobStatus, deprecated=True)
 async def create_job(
     request: CreateJobRequest,
     current_user: dict[str, Any] = Depends(get_current_user),
@@ -88,7 +88,22 @@ async def create_job(
     file_repo: FileRepository = Depends(create_file_repository),
     collection_repo: CollectionRepository = Depends(create_collection_repository),  # noqa: ARG001
 ) -> JobStatus:
-    """Create a new embedding job"""
+    """Create a new embedding job
+
+    **DEPRECATED**: This endpoint is deprecated and will be removed in v2.0.
+    Use collection-based operations instead:
+    - For new collections: Collections are created automatically when processing files
+    - For adding to existing collections: Use POST /api/jobs/add-to-collection
+
+    Migration guide:
+    1. Instead of creating individual jobs, work with collections as logical units
+    2. Collections group related documents and can span multiple indexing operations
+    3. Use /api/collections endpoints for management and /api/search for querying
+    """
+    logger.warning(
+        "POST /api/jobs is deprecated. Use collection-based operations instead. "
+        "This endpoint will be removed in v2.0."
+    )
     # Accept job_id from request if provided, otherwise generate new one
     job_id = request.job_id if request.job_id else str(uuid.uuid4())
 
@@ -397,12 +412,24 @@ async def add_to_collection(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@router.get("", response_model=list[JobStatus])
+@router.get("", response_model=list[JobStatus], deprecated=True)
 async def list_jobs(
     current_user: dict[str, Any] = Depends(get_current_user),
     job_repo: JobRepository = Depends(create_job_repository),
 ) -> list[JobStatus]:
-    """List all jobs for the current user"""
+    """List all jobs for the current user
+
+    **DEPRECATED**: This endpoint is deprecated and will be removed in v2.0.
+    Use GET /api/collections instead for a collection-centric view.
+
+    Migration guide:
+    1. GET /api/collections provides aggregated view of all collections
+    2. Each collection shows total files, vectors, and associated jobs
+    3. Use GET /api/collections/{name} for detailed job information per collection
+    """
+    logger.warning(
+        "GET /api/jobs is deprecated. Use GET /api/collections instead. This endpoint will be removed in v2.0."
+    )
     jobs = await job_repo.list_jobs(user_id=str(current_user["id"]))
 
     result = []
@@ -544,13 +571,26 @@ async def cancel_job(
     return {"message": "Job marked as cancelled (task revocation pending implementation)"}
 
 
-@router.delete("/{job_id}")
+@router.delete("/{job_id}", deprecated=True)
 async def delete_job(
     job_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),  # noqa: ARG001
     job_repo: JobRepository = Depends(create_job_repository),
 ) -> dict[str, str]:
-    """Delete a job and its associated collection"""
+    """Delete a job and its associated collection
+
+    **DEPRECATED**: This endpoint is deprecated and will be removed in v2.0.
+    Use DELETE /api/collections/{collection_name} instead.
+
+    Migration guide:
+    1. DELETE /api/collections/{name} removes entire collection and all associated jobs
+    2. This provides cleaner semantics for managing document sets
+    3. Deletion is atomic at the collection level
+    """
+    logger.warning(
+        f"DELETE /api/jobs/{job_id} is deprecated. Use DELETE /api/collections/{{collection_name}} instead. "
+        "This endpoint will be removed in v2.0."
+    )
     # Check if job exists
     job = await job_repo.get_job(job_id)
     if not job:
@@ -577,13 +617,26 @@ async def delete_job(
     return {"message": "Job deleted successfully"}
 
 
-@router.get("/{job_id}", response_model=JobStatus)
+@router.get("/{job_id}", response_model=JobStatus, deprecated=True)
 async def get_job(
     job_id: str,
     current_user: dict[str, Any] = Depends(get_current_user),  # noqa: ARG001
     job_repo: JobRepository = Depends(create_job_repository),
 ) -> JobStatus:
-    """Get job details"""
+    """Get job details
+
+    **DEPRECATED**: This endpoint is deprecated and will be removed in v2.0.
+    Use GET /api/collections/{collection_name} instead.
+
+    Migration guide:
+    1. Jobs are now grouped under collections
+    2. GET /api/collections/{name} shows all jobs for a collection
+    3. Collection details include configuration, stats, and job history
+    """
+    logger.warning(
+        f"GET /api/jobs/{job_id} is deprecated. Use GET /api/collections/{{collection_name}} instead. "
+        "This endpoint will be removed in v2.0."
+    )
     job = await job_repo.get_job(job_id)
 
     if not job:


### PR DESCRIPTION
## Summary
- Formal deprecation of job-centric API endpoints in favor of collection-based alternatives
- Added deprecation markers and migration guidance to prepare for eventual removal
- Created follow-up tickets for complete removal post-v2.0

## Changes
1. **Deprecated Job CRUD Endpoints** (`packages/webui/api/jobs.py`):
   - Added `deprecated=True` flag to FastAPI router decorators
   - Added warning logs when deprecated endpoints are used
   - Enhanced docstrings with migration guidance

2. **Deprecated Endpoints**:
   - `POST /api/jobs` → Use collection-based operations
   - `GET /api/jobs` → Use `GET /api/collections`
   - `GET /api/jobs/{job_id}` → Use `GET /api/collections/{name}`
   - `DELETE /api/jobs/{job_id}` → Use `DELETE /api/collections/{name}`

3. **NOT Deprecated**:
   - Collection-aware job endpoints (add-to-collection, metadata, etc.)
   - Utility endpoints (new-id, cancel)
   - WebSocket handlers (handled separately)

4. **Documentation**:
   - Created `DEPRECATED_ENDPOINTS_REMOVAL_TICKETS.md` with removal plan
   - Updated `PHASE_3_DEV_LOG.md` with implementation details

## Test Plan
- [x] All deprecated endpoints still function correctly
- [x] Warning logs are generated when deprecated endpoints are used
- [x] OpenAPI documentation shows deprecation status
- [x] All linting and type checking passes (black, ruff, mypy)
- [ ] Verify frontend still works with deprecated endpoints during transition

## Notes
- Since Semantik is pre-release, we have flexibility on removal timing
- Monitoring deprecated endpoint usage will help determine when safe to remove
- All functionality is available through collection-based endpoints