### PR TITLE
Phase 5B: Complete v2 API migration for rename and delete modals

### DIFF
--- a/PHASE_5_DEV_LOG.md
+++ b/PHASE_5_DEV_LOG.md
@@ -946,3 +946,70 @@ Completed removal of all UI components and state management related to the job s
 #### Summary
 
 Phase 5A is successfully completed. All job-related UI components have been removed from the frontend, and the application now focuses entirely on the collection-centric paradigm. The codebase is cleaner, tests are passing, and the UI is ready for the new collection-based workflow.
+
+---
+
+## Phase 5B: V2 API Consistency Verification
+
+### 2025-07-18: V2 API Migration Completion
+
+#### Overview
+Completed verification and migration of remaining v1 API usage in the frontend. Found and fixed two components that were still using the old collectionsApi, ensuring complete consistency with the v2 API structure.
+
+#### Issues Found and Fixed
+
+1. **RenameCollectionModal.tsx**
+   - Was importing and using `collectionsApi` from v1
+   - Updated to use `collectionsV2Api` from v2
+   - Added `collectionId` prop (UUID) since v2 API requires it
+   - Changed API call from `collectionsApi.rename(name, newName)` to `collectionsV2Api.update(collectionId, { name: newName })`
+   - Updated parent component (CollectionDetailsModal) to pass the collection ID
+
+2. **DeleteCollectionModal.tsx**
+   - Was importing and using `collectionsApi` from v1
+   - Updated to use `collectionsV2Api` from v2
+   - Added `collectionId` prop (UUID) since v2 API requires it
+   - Changed API call from `collectionsApi.delete(name)` to `collectionsV2Api.delete(collectionId)`
+   - Simplified success handling since v2 API returns void (no error details)
+   - Updated parent component (CollectionDetailsModal) to pass the collection ID
+
+3. **Removed old collectionsApi**
+   - Deleted the entire `collectionsApi` object from `services/api.ts`
+   - No other components were using it
+
+4. **Fixed SettingsPage test failures**
+   - Updated test to expect `collection_count` instead of `job_count`
+   - Changed expected text from "Total Jobs" to "Total Collections"
+   - Updated SettingsPage component to use `collection_count` field
+   - Fixed TypeScript interface to match new API structure
+
+#### Test Results
+
+- ✅ All frontend tests passing (152 passed, 1 skipped)
+- ✅ TypeScript compilation successful with no errors
+- ✅ Backend tests running without issues
+- ✅ No remaining imports of v1 collectionsApi found
+
+#### Verification Commands Used
+
+```bash
+# Search for v1 API imports
+grep -r "collectionsApi'" apps/webui-react/src/ --include="*.tsx" --include="*.ts"
+
+# Search for hardcoded v1 endpoints
+grep -r "/api/collections" apps/webui-react/src/ --include="*.tsx" --include="*.ts"
+
+# Search for old data structure references
+grep -r "\.configuration\.\|\.stats\." apps/webui-react/src/ --include="*.tsx" --include="*.ts"
+```
+
+#### Summary
+
+Phase 5B addendum is complete. All frontend components now exclusively use the v2 API:
+- ✅ No remaining v1 API imports
+- ✅ All components use UUID-based v2 endpoints
+- ✅ Data structures match v2 format (flat, not nested)
+- ✅ All tests updated and passing
+- ✅ Old collectionsApi removed from codebase
+
+The frontend is now fully consistent with the v2 collection-centric API architecture.

--- a/apps/webui-react/src/components/CollectionDetailsModal.tsx
+++ b/apps/webui-react/src/components/CollectionDetailsModal.tsx
@@ -701,6 +701,7 @@ function CollectionDetailsModal() {
 
       {showRenameModal && collection && (
         <RenameCollectionModal
+          collectionId={showCollectionDetailsModal}
           currentName={collection.name}
           onClose={() => setShowRenameModal(false)}
           onSuccess={handleRenameSuccess}
@@ -709,6 +710,7 @@ function CollectionDetailsModal() {
 
       {showDeleteModal && collection && (
         <DeleteCollectionModal
+          collectionId={showCollectionDetailsModal}
           collectionName={collection.name}
           stats={{
             total_files: collection.document_count,

--- a/apps/webui-react/src/components/DeleteCollectionModal.tsx
+++ b/apps/webui-react/src/components/DeleteCollectionModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { collectionsApi } from '../services/api';
+import { collectionsV2Api } from '../services/api/v2/collections';
 import { useUIStore } from '../stores/uiStore';
 
 interface CollectionStats {
@@ -11,6 +11,7 @@ interface CollectionStats {
 }
 
 interface DeleteCollectionModalProps {
+  collectionId: string;
   collectionName: string;
   stats: CollectionStats;
   onClose: () => void;
@@ -18,6 +19,7 @@ interface DeleteCollectionModalProps {
 }
 
 function DeleteCollectionModal({
+  collectionId,
   collectionName,
   stats,
   onClose,
@@ -29,19 +31,13 @@ function DeleteCollectionModal({
 
   const mutation = useMutation({
     mutationFn: async () => {
-      return collectionsApi.delete(collectionName);
+      return collectionsV2Api.delete(collectionId);
     },
-    onSuccess: (response) => {
-      const errors = response.data.errors;
-      
-      if (errors.qdrant_failures?.length > 0 || errors.artifact_failures?.length > 0) {
-        addToast({
-          type: 'warning',
-          message: `Collection deleted with some cleanup errors. Check logs for details.`,
-          duration: 10000,
-        });
-      }
-      
+    onSuccess: () => {
+      addToast({
+        type: 'success',
+        message: `Collection "${collectionName}" deleted successfully`,
+      });
       onSuccess();
     },
     onError: (error: any) => {

--- a/apps/webui-react/src/components/RenameCollectionModal.tsx
+++ b/apps/webui-react/src/components/RenameCollectionModal.tsx
@@ -1,15 +1,17 @@
 import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { collectionsApi } from '../services/api';
+import { collectionsV2Api } from '../services/api/v2/collections';
 import { useUIStore } from '../stores/uiStore';
 
 interface RenameCollectionModalProps {
+  collectionId: string;
   currentName: string;
   onClose: () => void;
   onSuccess: (newName: string) => void;
 }
 
 function RenameCollectionModal({
+  collectionId,
   currentName,
   onClose,
   onSuccess,
@@ -23,7 +25,7 @@ function RenameCollectionModal({
       if (newName === currentName) {
         throw new Error('New name must be different from current name');
       }
-      return collectionsApi.rename(currentName, newName);
+      return collectionsV2Api.update(collectionId, { name: newName });
     },
     onSuccess: () => {
       onSuccess(newName);

--- a/apps/webui-react/src/pages/SettingsPage.tsx
+++ b/apps/webui-react/src/pages/SettingsPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { settingsApi } from '../services/api';
 
 interface DatabaseStats {
-  job_count: number;
+  collection_count: number;
   file_count: number;
   database_size_mb: number;
   parquet_files_count: number;
@@ -107,7 +107,7 @@ function SettingsPage() {
                   <div className="text-sm text-gray-600">Total Collections</div>
                 </div>
                 <div className="text-2xl font-semibold mt-1">
-                  {formatNumber(stats.job_count)}
+                  {formatNumber(stats.collection_count)}
                 </div>
               </div>
               

--- a/apps/webui-react/src/pages/__tests__/LoginPage.test.tsx
+++ b/apps/webui-react/src/pages/__tests__/LoginPage.test.tsx
@@ -40,8 +40,7 @@ describe('LoginPage', () => {
     // Reset UI store and clear any existing toasts
     useUIStore.setState({
       toasts: [],
-      activeTab: 'create',
-      showJobMetricsModal: null,
+      activeTab: 'collections',
       showDocumentViewer: null,
       showCollectionDetailsModal: null,
     })

--- a/apps/webui-react/src/pages/__tests__/SettingsPage.test.tsx
+++ b/apps/webui-react/src/pages/__tests__/SettingsPage.test.tsx
@@ -5,7 +5,6 @@ import { http, HttpResponse } from 'msw'
 import { server } from '../../tests/mocks/server'
 import { render as renderWithProviders } from '../../tests/utils/test-utils'
 import SettingsPage from '../SettingsPage'
-import { useJobsStore } from '../../stores/jobsStore'
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
@@ -20,7 +19,7 @@ vi.mock('react-router-dom', async () => {
 global.alert = vi.fn()
 
 const mockStats = {
-  job_count: 15,
+  collection_count: 15,
   file_count: 250,
   database_size_mb: 128,
   parquet_files_count: 30,
@@ -32,10 +31,6 @@ describe('SettingsPage', () => {
     vi.clearAllMocks()
     mockNavigate.mockClear()
     
-    // Reset jobs store
-    useJobsStore.setState({
-      jobs: [],
-    })
     
     // Default handler for stats
     server.use(
@@ -74,7 +69,7 @@ describe('SettingsPage', () => {
     })
     
     // Check that stats are displayed
-    expect(screen.getByText('Total Jobs')).toBeInTheDocument()
+    expect(screen.getByText('Total Collections')).toBeInTheDocument()
     expect(screen.getByText('15')).toBeInTheDocument()
     
     expect(screen.getByText('Total Files')).toBeInTheDocument()
@@ -115,7 +110,7 @@ describe('SettingsPage', () => {
     server.use(
       http.get('/api/settings/stats', () => {
         return HttpResponse.json({
-          job_count: 1500,
+          collection_count: 1500,
           file_count: 25000,
           database_size_mb: 1024,
           parquet_files_count: 3000,
@@ -138,7 +133,7 @@ describe('SettingsPage', () => {
     
     expect(screen.getByText('Danger Zone')).toBeInTheDocument()
     expect(screen.getAllByText('Reset Database')).toHaveLength(2) // h4 and button
-    expect(screen.getByText(/This will delete all jobs, files, and associated data/)).toBeInTheDocument()
+    expect(screen.getByText(/This will delete all collections, files, and associated data/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reset database/i })).toBeInTheDocument()
   })
 
@@ -218,14 +213,6 @@ describe('SettingsPage', () => {
       })
     )
     
-    // Set some initial jobs
-    useJobsStore.setState({
-      jobs: [
-        { id: '1', name: 'Test Job', status: 'completed' } as any,
-        { id: '2', name: 'Another Job', status: 'running' } as any,
-      ],
-    })
-    
     renderWithProviders(<SettingsPage />)
     
     // Open dialog and confirm
@@ -242,9 +229,6 @@ describe('SettingsPage', () => {
     
     // Check navigation
     expect(mockNavigate).toHaveBeenCalledWith('/')
-    
-    // Check jobs were cleared
-    expect(useJobsStore.getState().jobs).toHaveLength(0)
     
     // Dialog should be closed
     expect(screen.queryByText('Confirm Database Reset')).not.toBeInTheDocument()
@@ -294,7 +278,7 @@ describe('SettingsPage', () => {
     
     // Check that all cards are rendered with their values
     const cards = [
-      { label: 'Total Jobs', value: '15' },
+      { label: 'Total Collections', value: '15' },
       { label: 'Total Files', value: '250' },
       { label: 'Database Size', value: '128 MB' },
       { label: 'Parquet Files', value: '30' },

--- a/apps/webui-react/src/services/api.ts
+++ b/apps/webui-react/src/services/api.ts
@@ -70,22 +70,6 @@ export const authApi = {
   logout: () => api.post('/api/auth/logout'),
 };
 
-// Collections API endpoints
-export const collectionsApi = {
-  list: () => api.get('/api/collections'),
-  getDetails: (name: string) => api.get(`/api/collections/${encodeURIComponent(name)}`),
-  rename: (name: string, newName: string) => 
-    api.put(`/api/collections/${encodeURIComponent(name)}`, { new_name: newName }),
-  delete: (name: string) => api.delete(`/api/collections/${encodeURIComponent(name)}`),
-  getFiles: (name: string, page: number = 1, limit: number = 50) => 
-    api.get(`/api/collections/${encodeURIComponent(name)}/files?page=${page}&limit=${limit}`),
-  addData: (collectionName: string, directoryPath: string, description?: string) =>
-    api.post('/api/jobs/add-to-collection', {
-      collection_name: collectionName,
-      directory_path: directoryPath,
-      description: description || `Adding documents to ${collectionName}`,
-    }),
-};
 
 // Models API endpoints
 export const modelsApi = {

--- a/packages/webui/static/index.html
+++ b/packages/webui/static/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Semantik - Document Embedding Pipeline</title>
-    <script type="module" crossorigin src="/assets/index-DphNxbm7.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CYx5RrPV.css">
+    <script type="module" crossorigin src="/assets/index-Dr9_93EB.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-C_RiHj91.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Completed v2 API migration for RenameCollectionModal and DeleteCollectionModal
- Removed all remaining v1 API usage from frontend components
- Fixed test failures related to job->collection terminology changes

## Changes Made

### API Migration
- **RenameCollectionModal**: Updated to use `collectionsV2Api.update()` with UUID
- **DeleteCollectionModal**: Updated to use `collectionsV2Api.delete()` with UUID
- Both modals now accept `collectionId` prop for UUID-based operations
- Updated parent component (CollectionDetailsModal) to pass collection IDs

### Cleanup
- Removed old `collectionsApi` object from `services/api.ts`
- No remaining v1 API imports in the frontend codebase

### Test Fixes
- Updated SettingsPage component to use `collection_count` field
- Fixed SettingsPage tests to expect "Total Collections" instead of "Total Jobs"
- All frontend tests now passing (152 passed, 1 skipped)

## Test Results
✅ All frontend tests passing
✅ TypeScript compilation successful
✅ No linting errors (black, ruff)
✅ No type checking errors (mypy)

## Verification
Ran comprehensive searches to ensure no v1 API usage remains:
```bash
grep -r "collectionsApi'" apps/webui-react/src/ --include="*.tsx" --include="*.ts"
grep -r "/api/collections" apps/webui-react/src/ --include="*.tsx" --include="*.ts"
```

This completes the Phase 5B addendum task for v2 API consistency verification.