### PR TITLE
Fix Frontend Authentication State Management

### DIFF
--- a/POST_PHASE_5_DEV_LOG.md
+++ b/POST_PHASE_5_DEV_LOG.md
@@ -1,0 +1,48 @@
+# Post Phase 5 Development Log
+
+## TICKET-001: Fix Frontend Authentication State Management
+
+### Initial Investigation
+
+**Finding 1: Auth Store Configuration**
+- The auth store is correctly configured with Zustand persist middleware
+- It should automatically save to localStorage with key 'auth-storage'
+- The store has proper setAuth and logout methods
+
+**Finding 2: Login Flow**
+- LoginPage correctly calls setAuth with access_token, user data, and refresh_token
+- The login endpoint is properly called and tokens are received
+
+**Finding 3: API Configuration**
+- API service correctly reads token from auth store using interceptors
+- Authorization headers are properly added when token exists
+
+**Finding 4: Tests**
+- Auth store tests pass, including localStorage persistence tests
+- This suggests the implementation is correct but there may be an environmental or timing issue
+
+### Runtime Testing Results
+
+**Finding 5: localStorage Storage Verification**
+- Confirmed that auth tokens ARE being stored in localStorage after login
+- The zustand persist middleware is working correctly
+- Token format: `auth-storage` key contains JSON with state object including token, refreshToken, and user
+
+**Finding 6: Collections Display Issue**
+- The real issue was not with auth storage but with missing `status` field in collection API response
+- Frontend expects status field (pending, ready, processing, error, degraded) but backend wasn't providing it
+- This caused collections to not display even though they were being fetched successfully
+
+**Finding 7: API Response Fix**
+- Updated `CollectionResponse` schema in `/packages/webui/api/schemas.py` to include:
+  - `status: str` field
+  - `status_message: str | None` field
+- Modified `from_collection` method to properly extract status from enum value
+
+**Finding 8: Logout Functionality**
+- Logout correctly clears localStorage
+- The `auth-storage` key is removed on logout
+- User is properly redirected to login page
+
+### Resolution
+The issue was resolved by adding the missing `status` field to the collection API response. Authentication was working correctly all along - the collections weren't displaying due to a schema mismatch between frontend expectations and backend response.

--- a/alembic/versions/ffe1d5e1664a_add_quantization_field_to_collections_.py
+++ b/alembic/versions/ffe1d5e1664a_add_quantization_field_to_collections_.py
@@ -5,30 +5,31 @@ Revises: 91784cc819aa
 Create Date: 2025-07-18 08:50:23.050916
 
 """
-from typing import Sequence, Union
 
-from alembic import op
+from collections.abc import Sequence
+
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = 'ffe1d5e1664a'
-down_revision: Union[str, Sequence[str], None] = '91784cc819aa'
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+revision: str = "ffe1d5e1664a"
+down_revision: str | Sequence[str] | None = "91784cc819aa"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
     """Upgrade schema."""
     # Add quantization column with default value for existing rows
-    with op.batch_alter_table('collections') as batch_op:
-        batch_op.add_column(sa.Column('quantization', sa.String(), nullable=False, server_default='float16'))
+    with op.batch_alter_table("collections") as batch_op:
+        batch_op.add_column(sa.Column("quantization", sa.String(), nullable=False, server_default="float16"))
     # Remove server default after adding column
-    with op.batch_alter_table('collections') as batch_op:
-        batch_op.alter_column('quantization', server_default=None)
+    with op.batch_alter_table("collections") as batch_op:
+        batch_op.alter_column("quantization", server_default=None)
 
 
 def downgrade() -> None:
     """Downgrade schema."""
     # Remove quantization column
-    op.drop_column('collections', 'quantization')
+    op.drop_column("collections", "quantization")

--- a/packages/shared/database/__init__.py
+++ b/packages/shared/database/__init__.py
@@ -14,8 +14,9 @@ Import Organization:
 """
 
 from .base import AuthRepository, BaseRepository, CollectionRepository, FileRepository, JobRepository, UserRepository
-from .collection_metadata import ensure_metadata_collection, store_collection_metadata
+from .collection_metadata import ensure_metadata_collection
 from .collection_metadata import get_collection_metadata as get_collection_metadata_qdrant
+from .collection_metadata import store_collection_metadata
 
 # Async database session management
 from .database import get_db

--- a/packages/shared/database/__init__.py
+++ b/packages/shared/database/__init__.py
@@ -14,9 +14,8 @@ Import Organization:
 """
 
 from .base import AuthRepository, BaseRepository, CollectionRepository, FileRepository, JobRepository, UserRepository
-from .collection_metadata import ensure_metadata_collection
+from .collection_metadata import ensure_metadata_collection, store_collection_metadata
 from .collection_metadata import get_collection_metadata as get_collection_metadata_qdrant
-from .collection_metadata import store_collection_metadata
 
 # Async database session management
 from .database import get_db

--- a/packages/shared/database/factory.py
+++ b/packages/shared/database/factory.py
@@ -4,7 +4,8 @@ This module provides factory functions to create repository instances,
 allowing for easy switching between different implementations.
 """
 
-from typing import Any, Callable, Coroutine, Optional
+from collections.abc import Callable, Coroutine
+from typing import Any
 
 from .base import AuthRepository, CollectionRepository, FileRepository, JobRepository, UserRepository
 from .sqlite_repository import (
@@ -109,8 +110,8 @@ def create_operation_repository() -> Any:
         """Async wrapper that manages its own database session."""
 
         def __init__(self) -> None:
-            self._session: Optional[Any] = None  # AsyncSession
-            self._repo: Optional[Any] = None  # OperationRepository
+            self._session: Any | None = None  # AsyncSession
+            self._repo: Any | None = None  # OperationRepository
 
         async def _ensure_initialized(self) -> None:
             """Ensure repository is initialized with a session."""
@@ -155,8 +156,8 @@ def create_document_repository() -> Any:
         """Async wrapper that manages its own database session."""
 
         def __init__(self) -> None:
-            self._session: Optional[Any] = None  # AsyncSession
-            self._repo: Optional[Any] = None  # DocumentRepository
+            self._session: Any | None = None  # AsyncSession
+            self._repo: Any | None = None  # DocumentRepository
 
         async def _ensure_initialized(self) -> None:
             """Ensure repository is initialized with a session."""

--- a/packages/shared/database/factory.py
+++ b/packages/shared/database/factory.py
@@ -101,7 +101,6 @@ def create_operation_repository() -> Any:
     Note: This is a compatibility shim for the new async repositories.
     The actual implementation will create a session and repository on first use.
     """
-    import asyncio
 
     from .database import AsyncSessionLocal
     from .repositories.operation_repository import OperationRepository
@@ -147,7 +146,6 @@ def create_document_repository() -> Any:
     Note: This is a compatibility shim for the new async repositories.
     The actual implementation will create a session and repository on first use.
     """
-    import asyncio
 
     from .database import AsyncSessionLocal
     from .repositories.document_repository import DocumentRepository

--- a/packages/shared/database/factory.py
+++ b/packages/shared/database/factory.py
@@ -97,87 +97,91 @@ def create_all_repositories() -> dict[str, object]:
 
 def create_operation_repository() -> Any:
     """Create an operation repository instance.
-    
+
     Note: This is a compatibility shim for the new async repositories.
     The actual implementation will create a session and repository on first use.
     """
     import asyncio
+
     from .database import AsyncSessionLocal
     from .repositories.operation_repository import OperationRepository
-    
+
     class AsyncOperationRepositoryWrapper:
         """Async wrapper that manages its own database session."""
-        
+
         def __init__(self):
             self._session = None
             self._repo = None
-        
+
         async def _ensure_initialized(self):
             """Ensure repository is initialized with a session."""
             if self._repo is None:
                 self._session = AsyncSessionLocal()
                 self._repo = OperationRepository(self._session)
-        
+
         async def __aenter__(self):
             await self._ensure_initialized()
             return self
-        
+
         async def __aexit__(self, exc_type, exc_val, exc_tb):
             if self._session:
                 await self._session.close()
-        
+
         def __getattr__(self, name):
             """Proxy all attribute access to the repository."""
+
             async def async_wrapper(*args, **kwargs):
                 await self._ensure_initialized()
                 result = await getattr(self._repo, name)(*args, **kwargs)
                 await self._session.commit()  # Auto-commit for compatibility
                 return result
-            
+
             return async_wrapper
-    
+
     return AsyncOperationRepositoryWrapper()
 
 
 def create_document_repository() -> Any:
     """Create a document repository instance.
-    
+
     Note: This is a compatibility shim for the new async repositories.
     The actual implementation will create a session and repository on first use.
     """
     import asyncio
+
     from .database import AsyncSessionLocal
     from .repositories.document_repository import DocumentRepository
-    
+
     class AsyncDocumentRepositoryWrapper:
         """Async wrapper that manages its own database session."""
-        
+
         def __init__(self):
             self._session = None
             self._repo = None
-        
+
         async def _ensure_initialized(self):
             """Ensure repository is initialized with a session."""
             if self._repo is None:
                 self._session = AsyncSessionLocal()
                 self._repo = DocumentRepository(self._session)
-        
+
         async def __aenter__(self):
             await self._ensure_initialized()
             return self
-        
+
         async def __aexit__(self, exc_type, exc_val, exc_tb):
             if self._session:
                 await self._session.close()
-        
+
         def __getattr__(self, name):
             """Proxy all attribute access to the repository."""
+
             async def async_wrapper(*args, **kwargs):
                 await self._ensure_initialized()
                 result = await getattr(self._repo, name)(*args, **kwargs)
                 await self._session.commit()  # Auto-commit for compatibility
                 return result
-            
+
             return async_wrapper
-    
+
     return AsyncDocumentRepositoryWrapper()

--- a/packages/webui/api/schemas.py
+++ b/packages/webui/api/schemas.py
@@ -133,12 +133,8 @@ class AddSourceRequest(BaseModel):
         None,
         description="Optional configuration for the source",
         json_schema_extra={
-            "example": {
-                "chunk_size": 1000,
-                "chunk_overlap": 200,
-                "metadata": {"department": "engineering"}
-            }
-        }
+            "example": {"chunk_size": 1000, "chunk_overlap": 200, "metadata": {"department": "engineering"}}
+        },
     )
 
 
@@ -151,6 +147,8 @@ class CollectionResponse(CollectionBase):
     created_at: datetime
     updated_at: datetime
     document_count: int | None = 0
+    status: str  # Collection status: pending, ready, processing, error, degraded
+    status_message: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -172,6 +170,8 @@ class CollectionResponse(CollectionBase):
             created_at=collection.created_at,
             updated_at=collection.updated_at,
             document_count=collection.document_count,
+            status=collection.status.value if hasattr(collection.status, "value") else collection.status,
+            status_message=getattr(collection, "status_message", None),
         )
 
 

--- a/packages/webui/api/v2/collections.py
+++ b/packages/webui/api/v2/collections.py
@@ -98,6 +98,8 @@ async def create_collection(
             created_at=collection["created_at"],
             updated_at=collection["updated_at"],
             document_count=collection["document_count"],
+            status=collection["status"],
+            status_message=collection.get("status_message"),
         )
 
     except EntityAlreadyExistsError as e:

--- a/packages/webui/tasks.py
+++ b/packages/webui/tasks.py
@@ -1189,7 +1189,6 @@ def _handle_task_failure(
 
 async def _handle_task_failure_async(operation_id: str, exc: Exception, task_id: str) -> None:
     """Async implementation of failure handling."""
-    from shared.database.factory import create_collection_repository, create_operation_repository
     from shared.database.models import CollectionStatus, OperationStatus, OperationType
     from shared.metrics.collection_metrics import collection_operations_total
 
@@ -1427,11 +1426,6 @@ def process_collection_operation(self: Any, operation_id: str) -> dict[str, Any]
 
 async def _process_collection_operation_async(operation_id: str, celery_task: Any) -> dict[str, Any]:
     """Async implementation of collection operation processing with enhanced monitoring."""
-    from shared.database.factory import (
-        create_collection_repository,
-        create_document_repository,
-        create_operation_repository,
-    )
     from shared.database.models import CollectionStatus, OperationStatus, OperationType
 
     start_time = time.time()

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -127,8 +127,8 @@ class TestMigrations:
         # Insert collection
         cursor.execute(
             """INSERT INTO collections (id, name, description, owner_id, vector_store_name,
-               embedding_model, chunk_size, chunk_overlap, is_public, created_at, updated_at, status)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               embedding_model, quantization, chunk_size, chunk_overlap, is_public, created_at, updated_at, status)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 "coll1",
                 "Test Collection",
@@ -136,6 +136,7 @@ class TestMigrations:
                 user_id,
                 "vec_store_1",
                 "model1",
+                "float16",
                 1000,
                 200,
                 0,


### PR DESCRIPTION
## Summary
- Fixed missing status field in CollectionResponse schema that was preventing collections from displaying in the UI
- Authentication was working correctly - the issue was a schema mismatch between frontend and backend

## Problem
The frontend authentication state management appeared broken because collections created via API were not showing in the UI. Investigation revealed that auth tokens were being stored correctly in localStorage, but the collections weren't displaying due to a missing `status` field in the API response.

## Solution
1. Added `status` and `status_message` fields to the `CollectionResponse` schema
2. Updated the `from_collection` method to properly extract status from enum value
3. Fixed the `create_collection` endpoint to include status in the response
4. Applied linting fixes to related files

## Test Plan
- [x] Verified auth tokens are stored in localStorage after login
- [x] Confirmed collections API returns proper status field
- [x] Tested logout clears localStorage correctly
- [x] Collections now display properly in the UI
- [x] All linting and type checks pass