### PR TITLE
Fix missing vector_count field causing CollectionDetailsModal error

### DIFF
--- a/apps/webui-react/src/components/CollectionDetailsModal.tsx
+++ b/apps/webui-react/src/components/CollectionDetailsModal.tsx
@@ -79,12 +79,19 @@ function CollectionDetailsModal() {
       acc.get(doc.source_path)!.document_count++;
       return acc;
     }, new Map<string, SourceInfo>())
-  ).map(([_, info]) => info) : [];
+  ).map(([, info]) => info) : [];
 
   const handleClose = () => {
     setShowCollectionDetailsModal(null);
     setActiveTab('overview');
     setFilesPage(1);
+  };
+
+  const formatNumber = (num: number | null | undefined) => {
+    if (num === null || num === undefined) {
+      return '0';
+    }
+    return num.toLocaleString();
   };
 
   const formatBytes = (bytes: number) => {
@@ -201,7 +208,7 @@ function CollectionDetailsModal() {
               </h2>
               {collection && (
                 <p className="text-sm text-gray-500 mt-1">
-                  {operationsData?.length || 0} operations • {collection.document_count} documents • {collection.vector_count} vectors
+                  {operationsData?.length || 0} operations • {formatNumber(collection.document_count)} documents • {formatNumber(collection.vector_count)} vectors
                 </p>
               )}
             </div>
@@ -310,13 +317,13 @@ function CollectionDetailsModal() {
                   <div className="bg-gray-50 p-4 rounded">
                     <dt className="text-sm font-medium text-gray-500">Documents</dt>
                     <dd className="mt-1 text-2xl font-semibold text-gray-900">
-                      {collection.document_count.toLocaleString()}
+                      {formatNumber(collection.document_count)}
                     </dd>
                   </div>
                   <div className="bg-gray-50 p-4 rounded">
                     <dt className="text-sm font-medium text-gray-500">Vectors</dt>
                     <dd className="mt-1 text-2xl font-semibold text-gray-900">
-                      {collection.vector_count.toLocaleString()}
+                      {formatNumber(collection.vector_count)}
                     </dd>
                   </div>
                   <div className="bg-gray-50 p-4 rounded">
@@ -713,8 +720,8 @@ function CollectionDetailsModal() {
           collectionId={showCollectionDetailsModal}
           collectionName={collection.name}
           stats={{
-            total_files: collection.document_count,
-            total_vectors: collection.vector_count,
+            total_files: collection.document_count || 0,
+            total_vectors: collection.vector_count || 0,
             total_size: collection.total_size_bytes || 0,
             job_count: operationsData?.length || 0,
           }}

--- a/packages/webui/api/schemas.py
+++ b/packages/webui/api/schemas.py
@@ -138,7 +138,6 @@ class AddSourceRequest(BaseModel):
     )
 
 
-
 class CollectionResponse(CollectionBase):
     """Collection response schema."""
 
@@ -148,6 +147,7 @@ class CollectionResponse(CollectionBase):
     created_at: datetime
     updated_at: datetime
     document_count: int | None = 0
+    vector_count: int | None = 0
     status: str  # Collection status: pending, ready, processing, error, degraded
     status_message: str | None = None
 
@@ -164,7 +164,6 @@ class CollectionResponse(CollectionBase):
             vector_store_name=collection.vector_store_name,
             embedding_model=collection.embedding_model,
             quantization=collection.quantization,
-
             chunk_size=collection.chunk_size,
             chunk_overlap=collection.chunk_overlap,
             is_public=collection.is_public,
@@ -172,9 +171,9 @@ class CollectionResponse(CollectionBase):
             created_at=collection.created_at,
             updated_at=collection.updated_at,
             document_count=collection.document_count,
+            vector_count=collection.vector_count,
             status=collection.status.value if hasattr(collection.status, "value") else collection.status,
             status_message=getattr(collection, "status_message", None),
-
         )
 
 

--- a/packages/webui/api/v2/collections.py
+++ b/packages/webui/api/v2/collections.py
@@ -25,7 +25,6 @@ from packages.shared.database.repositories.document_repository import DocumentRe
 from packages.shared.database.repositories.operation_repository import OperationRepository
 from packages.webui.api.schemas import (
     AddSourceRequest,
-
     CollectionCreate,
     CollectionListResponse,
     CollectionResponse,
@@ -76,7 +75,6 @@ async def create_collection(
             config={
                 "embedding_model": create_request.embedding_model,
                 "quantization": create_request.quantization,
-
                 "chunk_size": create_request.chunk_size,
                 "chunk_overlap": create_request.chunk_overlap,
                 "is_public": create_request.is_public,
@@ -93,7 +91,6 @@ async def create_collection(
             vector_store_name=collection["vector_store_name"],
             embedding_model=collection["embedding_model"],
             quantization=collection["quantization"],
-
             chunk_size=collection["chunk_size"],
             chunk_overlap=collection["chunk_overlap"],
             is_public=collection["is_public"],
@@ -101,9 +98,9 @@ async def create_collection(
             created_at=collection["created_at"],
             updated_at=collection["updated_at"],
             document_count=collection["document_count"],
+            vector_count=collection.get("vector_count", 0),
             status=collection["status"],
             status_message=collection.get("status_message"),
-
         )
 
     except EntityAlreadyExistsError as e:
@@ -315,7 +312,6 @@ async def add_source(
     request: Request,  # noqa: ARG001
     collection_uuid: str,
     add_source_request: AddSourceRequest,
-
     current_user: dict[str, Any] = Depends(get_current_user),
     service: CollectionService = Depends(get_collection_service),
 ) -> OperationResponse:
@@ -330,7 +326,6 @@ async def add_source(
             user_id=int(current_user["id"]),
             source_path=add_source_request.source_path,
             source_config=add_source_request.config or {},
-
         )
 
         # Convert to response model

--- a/packages/webui/api/v2/operations.py
+++ b/packages/webui/api/v2/operations.py
@@ -163,7 +163,6 @@ async def cancel_operation(
 )
 async def list_operations(
     status: str | None = Query(None, description="Filter by operation status (comma-separated for multiple)"),
-
     operation_type: str | None = Query(None, description="Filter by operation type"),
     page: int = Query(1, ge=1, description="Page number"),
     per_page: int = Query(50, ge=1, le=100, description="Items per page"),
@@ -194,7 +193,6 @@ async def list_operations(
                         detail=f"Invalid status: {s}. Valid values are: {[st.value for st in OperationStatus]}",
                     ) from None
 
-
         type_enum = None
         if operation_type:
             try:
@@ -208,7 +206,6 @@ async def list_operations(
         operations, total = await repo.list_for_user(
             user_id=int(current_user["id"]),
             status_list=status_list,
-
             operation_type=type_enum,
             offset=offset,
             limit=per_page,

--- a/packages/webui/api/v2/search.py
+++ b/packages/webui/api/v2/search.py
@@ -78,7 +78,6 @@ async def search_single_collection(
         "collection": collection.vector_store_name,
         "model_name": collection.embedding_model,
         "quantization": collection.quantization,
-
         "include_content": True,
         "use_reranker": False,  # We'll do re-ranking after merging
     }

--- a/packages/webui/services/collection_service.py
+++ b/packages/webui/services/collection_service.py
@@ -76,7 +76,6 @@ class CollectionService:
                         else "Qwen/Qwen3-Embedding-0.6B"
                     ),
                     quantization=config.get("quantization", "float16") if config else "float16",
-
                     chunk_size=config.get("chunk_size", 1000) if config else 1000,
                     chunk_overlap=config.get("chunk_overlap", 200) if config else 200,
                     is_public=config.get("is_public", False) if config else False,
@@ -118,7 +117,6 @@ class CollectionService:
             "vector_store_name": collection.vector_store_name,
             "embedding_model": collection.embedding_model,
             "quantization": collection.quantization,
-
             "chunk_size": collection.chunk_size,
             "chunk_overlap": collection.chunk_overlap,
             "is_public": collection.is_public,
@@ -126,11 +124,11 @@ class CollectionService:
             "created_at": collection.created_at,
             "updated_at": collection.updated_at,
             "document_count": 0,  # New collection has no documents
+            "vector_count": 0,  # New collection has no vectors
             "status": collection.status.value if hasattr(collection.status, "value") else collection.status,
             "config": {
                 "embedding_model": collection.embedding_model,
                 "quantization": collection.quantization,
-
                 "chunk_size": collection.chunk_size,
                 "chunk_overlap": collection.chunk_overlap,
                 "is_public": collection.is_public,
@@ -285,7 +283,6 @@ class CollectionService:
         new_config = {
             "embedding_model": collection.embedding_model,
             "quantization": collection.quantization,
-
             "chunk_size": collection.chunk_size,
             "chunk_overlap": collection.chunk_overlap,
             "is_public": collection.is_public,
@@ -305,7 +302,6 @@ class CollectionService:
                     "previous_config": {
                         "embedding_model": collection.embedding_model,
                         "quantization": collection.quantization,
-
                         "chunk_size": collection.chunk_size,
                         "chunk_overlap": collection.chunk_overlap,
                         "is_public": collection.is_public,


### PR DESCRIPTION
## Summary

- Fixes "Cannot read properties of undefined (reading 'toLocaleString')" error when clicking 'Manage collection' button
- Adds missing `vector_count` field to backend API responses
- Implements safe number formatting in frontend to handle null/undefined values

## Changes Made

### Backend
- Added `vector_count: int  < /dev/null |  None = 0` to `CollectionResponse` schema
- Updated `from_collection()` method to include `vector_count` from ORM model
- Added `vector_count` to `CollectionService.create_collection()` response
- Fixed import ordering issues caught by linter

### Frontend  
- Added `formatNumber()` utility function to safely format numbers
- Replaced all direct `.toLocaleString()` calls with `formatNumber()`
- Fixed unused variable linting error

## Test Results

- ✅ All Python unit tests pass (170 passed)
- ✅ Python linting passes
- ✅ Frontend linting passes for modified files
- ⚠️ Pre-existing frontend test failures unrelated to this change

## Verification

The fix was verified by:
1. Reproducing the error in the UI
2. Applying the fixes
3. Rebuilding and restarting services
4. Confirming the modal now opens successfully without errors