### PR TITLE
Fix collection deletion and database reset issues

### DIFF
--- a/apps/webui-react/src/pages/SettingsPage.tsx
+++ b/apps/webui-react/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { settingsApi } from '../services/api';
+import { useCollectionStore } from '../stores/collectionStore';
 
 interface DatabaseStats {
   collection_count: number;
@@ -45,6 +46,9 @@ function SettingsPage() {
     try {
       setResetting(true);
       await settingsApi.resetDatabase();
+      
+      // Clear the collection store to remove cached data
+      useCollectionStore.getState().clearStore();
       
       // Show success message and redirect
       alert('Database reset successfully!');

--- a/packages/webui/main.py
+++ b/packages/webui/main.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 from .api import (  # noqa: E402
     auth,
-    collections,
     documents,
     files,
     health,
@@ -189,7 +188,7 @@ def create_app() -> FastAPI:
     app.include_router(auth.router)
     app.include_router(jobs.router)
     app.include_router(files.router)
-    app.include_router(collections.router)
+    # app.include_router(collections.router)  # Removed v1 collections API - using v2 exclusively
     app.include_router(metrics.router)
     app.include_router(settings.router)
     app.include_router(models.router)


### PR DESCRIPTION
## Summary
- Fixed collection deletion failing with "failed to delete collection" error
- Fixed database reset not clearing collections in the UI
- Removed unused import to fix linting warning

## Problem Details

### 1. Collection Deletion Issue
Collections couldn't be deleted through the UI. The delete operation was failing because the v1 collections API endpoint had broken code trying to call `clear_collection_store()` which doesn't exist in the backend context.

### 2. Database Reset Issue  
After performing a database reset through the settings page, the old collections would still appear in the UI despite the database being cleared. This was because the frontend collection store wasn't being cleared after the reset.

## Solution

1. **Removed v1 collections router** from `main.py` since the frontend exclusively uses the v2 API. This eliminates the broken endpoint that was causing deletion failures.

2. **Updated SettingsPage.tsx** to clear the collection store after a successful database reset using `useCollectionStore.getState().clearStore()`.

3. **Fixed linting issue** by removing the unused collections import from main.py.

## Test Plan
- [x] Tested collection deletion - works correctly now
- [x] Tested database reset - UI properly reflects cleared state
- [x] Verified no regressions in collection management
- [x] Backend linting passes
- [x] Backend type checking passes